### PR TITLE
feat: example of @vocab using energy-storage cred

### DIFF
--- a/credentials/2022-neo/energy-storage/energy-storage-context-vocab.json
+++ b/credentials/2022-neo/energy-storage/energy-storage-context-vocab.json
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "@vocab": "https://vc-context.elia.be/2022/v1/"
+  }
+}

--- a/credentials/2022-neo/energy-storage/energy-storage-credential-vocab.json
+++ b/credentials/2022-neo/energy-storage/energy-storage-credential-vocab.json
@@ -1,0 +1,23 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://vc-context.elia.be/2022/v1/energy-storage"
+  ],
+  "type": [
+    "VerifiableCredential",
+    "EnergyStorageDeviceCredential"
+  ],
+  "id": "<some URI, e.g. https://elia.be/credential/1>",
+  "credentialSubject": {
+    "type": "EnergyStorageDevice",
+    "id": "deviceIdScheme:123",
+    "capacityTotalTheoretical": 10,
+    "cRateAllowed": "0.5C",
+    "cellChemistry": ["chemical1", "chemical2"],
+    "depthOfDischarge": 10,
+    "annualizedWarrantyCapacity": 10,
+    "bmsFeedbackLoopAvailable": true
+  },
+  "issuer": "did:example:dso",
+  "issuanceDate": "2021-05-14T12:55:30Z"
+}

--- a/credentials/2022-neo/energy-storage/energy-storage.test.ts
+++ b/credentials/2022-neo/energy-storage/energy-storage.test.ts
@@ -1,5 +1,6 @@
 import { Options, compact } from 'jsonld'
 import credential from './energy-storage-credential.json'
+import vocabCredential from './energy-storage-credential-vocab.json'
 import { issueAndVerify } from '../../../test/issue-and-verify'
 import { digitalBazaarDocumentLoader, transmuteDocumentLoader } from '../neo-document-loader'
 
@@ -46,4 +47,13 @@ describe("Energy Storage", () => {
     }
     expect(compacted).toEqual(expected)
   })
+})
+
+test("Explicit context credential is the same as vocab", async () => {
+  const options: Options.Compact = {
+    documentLoader: digitalBazaarDocumentLoader
+  }
+  const compactedCredential = await compact(credential, {}, options)
+  const compactedVocabCredential = await compact(vocabCredential, {}, options)
+  expect(compactedCredential).toEqual(compactedVocabCredential)
 })

--- a/credentials/2022-neo/neo-document-loader.ts
+++ b/credentials/2022-neo/neo-document-loader.ts
@@ -4,6 +4,7 @@ import deviceInfoContext from './device-info/device-info-context.json'
 import deviceLocationContext from './device-location/device-location-context.json'
 import energyLocationContext from './energy-location/energy-location-context.json'
 import energyStorageContext from './energy-storage/energy-storage-context.json'
+import energyStorageContextVocab from './energy-storage/energy-storage-context-vocab.json'
 import meteringDeviceContext from './metering-device/metering-device-context.json'
 import productionContext from './production/production-context.json'
 import steeringListContext from './steering-list/steering-list-context.json'
@@ -16,6 +17,7 @@ const contextMap = Object.assign({
     'https://vc-context.elia.be/2022/v1/device-location': deviceLocationContext,
     'https://vc-context.elia.be/2022/v1/energy-location': energyLocationContext,
     'https://vc-context.elia.be/2022/v1/energy-storage': energyStorageContext,
+    'https://vc-context.elia.be/2022/v1/energy-storage-vocab': energyStorageContextVocab,
     'https://vc-context.elia.be/2022/v1/metering-device': meteringDeviceContext,
     'https://vc-context.elia.be/2022/v1/production': productionContext,
     'https://vc-context.elia.be/2022/v1/steering-list': steeringListContext,


### PR DESCRIPTION
Adds example credential that uses `@vocab` keyword to get default vocabulary and a test that shows that it is equivalent to explicit context.