### PR TITLE
feat: add initial-tldr-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,39 @@ npm i
 npm test
 ```
 
+## TreeLDR
+
+From [TreeLDR documentation](https://www.sprucekit.dev/treeldr/treeldr):
+> TreeLDR is a schema definition language that aims at describing both the structure and semantics of the defined schema in a comprehensible way.
+> It lies at the intersection between RDF (and its various schema definition ontologies such as OWL) and structure-oriented schema definition frameworks such as JSON Schema or IPLD.
+
+To use TreeLDR:
+
+1. Install as described [here](https://www.sprucekit.dev/treeldr/treeldr-quickstart#installation)
+
+2. Navigate to the `treeldr-demo` directory
+```
+cd treeldr-demo
+```
+
+3. Run the TreeLDR CLI to compile the TreeLDR schema to JSON Schema
+```
+tldrc -i device-info.tldr json-schema https://vc-context.elia.be/2022/v1/Device
+```
+
+4. Run the TreeLDR CLI to compile the TreeLDR schema to JSON-LD
+```
+tldrc -i device-info.tldr json-ld-context https://vc-context.elia.be/2022/v1/Device
+```
+
+### How TreeLDR could be use to define credentials
+
+1. Create a new file for the credential
+2. If necessary, define new properties by selecting IRI from an RDF ontology and adding structure schema type (e.g. `string`, `number`, `boolean`, `array`, `object`)
+3. Compose the properties into a TreeLDR Type to be used as the `credentialSubject`
+4. Compose a new credential type from the `credentialSubject` type and a credentialType (TBD if this is possible, see https://www.sprucekit.dev/treeldr/treeldr-basics/syntax#composite-types) 
+
+
 # Types of files
 
 ## Linked Data Context

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ tldrc -i device-info.tldr json-ld-context https://vc-context.elia.be/2022/v1/Dev
 3. Compose the properties into a TreeLDR Type to be used as the `credentialSubject`
 4. Compose a new credential type from the `credentialSubject` type and a credentialType (TBD if this is possible, see https://www.sprucekit.dev/treeldr/treeldr-basics/syntax#composite-types) 
 
+Possible CLI steps for credential creation to automate the above steps:
+1. Define a TreeLDR type for the credential subject
+2. Compile the TreeLDR to to JSON-LD context -> this goes in the `@context` array of the credential 
+3. Ask for the IRI of the credential type -> this goes in the credential type array
+
 
 # Types of files
 

--- a/credentials/2022-neo/device-info/device-info-credential-treeldr.json
+++ b/credentials/2022-neo/device-info/device-info-credential-treeldr.json
@@ -1,0 +1,29 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    {
+      "@context": {
+        "Device": {
+          "@id": "https://vc-context.elia.be/2022/v1/Device",
+          "@context": {
+            "brandName": "https://saref.etsi.org/saref4ener/brandName",
+            "deviceCode": "https://saref.etsi.org/saref4ener/deviceCode"
+          }
+        }
+      }
+    }
+  ],
+  "type": [
+    "VerifiableCredential",
+    "https://vc-context.elia.be/2022/v1/DeviceInfoCredential"
+  ],
+  "id": "<some URI, e.g. https://elia.be/credential/1>",
+  "credentialSubject": {
+    "type": "Device",
+    "id": "deviceIdScheme:123",
+    "brandName": "Device Manufacturer Inc",
+    "deviceCode": "device 123"
+  },
+  "issuer": "did:example:dso",
+  "issuanceDate": "2021-05-14T12:55:30Z"
+}

--- a/credentials/2022-neo/device-info/device-info-credential-treeldr.json
+++ b/credentials/2022-neo/device-info/device-info-credential-treeldr.json
@@ -2,15 +2,9 @@
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
     {
-      "@context": {
-        "Device": {
-          "@id": "https://vc-context.elia.be/2022/v1/Device",
-          "@context": {
-            "brandName": "https://saref.etsi.org/saref4ener/brandName",
-            "deviceCode": "https://saref.etsi.org/saref4ener/deviceCode"
-          }
-        }
-      }
+      "Device": "https://vc-context.elia.be/2022/v1/Device",
+      "brandName": "https://saref.etsi.org/saref4ener/brandName",
+      "deviceCode": "https://saref.etsi.org/saref4ener/deviceCode"
     }
   ],
   "type": [

--- a/treeldr-demo/device-info.tldr
+++ b/treeldr-demo/device-info.tldr
@@ -2,7 +2,7 @@ base <https://vc-context.elia.be/2022/v1/>;
 use <https://vc-context.elia.be/2022/v1/> as elia;
 use <http://www.w3.org/2001/XMLSchema#> as xs;
 use <https://saref.etsi.org/saref4ener/> as saref4ener;
-use <https://www.w3.org/2018/credentials#> as vc;
+use <https://www.w3.org/2018/credentials#> as cred;
 
 property saref4ener:brandName: xs:string;
 property saref4ener:deviceCode: xs:string;
@@ -13,6 +13,12 @@ type Device {
   saref4ener:deviceCode
 }
 
+// tldrc -i device-info.tldr json-schema https://vc-context.elia.be/2022/v1/DeviceInfoCredential
 type DeviceInfoCredential {
   elia:Device
 }
+
+type cred:VerifiableCredential {
+}
+
+type DeviceInfoVC = DeviceInfoCredential | cred:VerifiableCredential;

--- a/treeldr-demo/device-info.tldr
+++ b/treeldr-demo/device-info.tldr
@@ -1,0 +1,11 @@
+base <https://vc-context.elia.be/2022/v1/>;
+use <http://www.w3.org/2001/XMLSchema#> as xs;
+use <https://saref.etsi.org/saref4ener/> as saref4ener;
+
+property saref4ener:brandName: xs:string;
+property saref4ener:deviceCode: xs:string;
+
+type Device {
+  saref4ener:brandName,
+  saref4ener:deviceCode
+}

--- a/treeldr-demo/device-info.tldr
+++ b/treeldr-demo/device-info.tldr
@@ -1,24 +1,13 @@
 base <https://vc-context.elia.be/2022/v1/>;
-use <https://vc-context.elia.be/2022/v1/> as elia;
 use <http://www.w3.org/2001/XMLSchema#> as xs;
 use <https://saref.etsi.org/saref4ener/> as saref4ener;
-use <https://www.w3.org/2018/credentials#> as cred;
 
 property saref4ener:brandName: xs:string;
 property saref4ener:deviceCode: xs:string;
-property elia:Device: Device;
 
+// tldrc -i device-info.tldr json-ld-context https://vc-context.elia.be/2022/v1/Device
+// tldrc -i device-info.tldr json-schema https://vc-context.elia.be/2022/v1/Device
 type Device {
   saref4ener:brandName,
   saref4ener:deviceCode
 }
-
-// tldrc -i device-info.tldr json-schema https://vc-context.elia.be/2022/v1/DeviceInfoCredential
-type DeviceInfoCredential {
-  elia:Device
-}
-
-type cred:VerifiableCredential {
-}
-
-type DeviceInfoVC = DeviceInfoCredential | cred:VerifiableCredential;

--- a/treeldr-demo/device-info.tldr
+++ b/treeldr-demo/device-info.tldr
@@ -1,11 +1,18 @@
 base <https://vc-context.elia.be/2022/v1/>;
+use <https://vc-context.elia.be/2022/v1/> as elia;
 use <http://www.w3.org/2001/XMLSchema#> as xs;
 use <https://saref.etsi.org/saref4ener/> as saref4ener;
+use <https://www.w3.org/2018/credentials#> as vc;
 
 property saref4ener:brandName: xs:string;
 property saref4ener:deviceCode: xs:string;
+property elia:Device: Device;
 
 type Device {
   saref4ener:brandName,
   saref4ener:deviceCode
+}
+
+type DeviceInfoCredential {
+  elia:Device
 }

--- a/treeldr-demo/spruce-demo-schema.tldr
+++ b/treeldr-demo/spruce-demo-schema.tldr
@@ -1,0 +1,23 @@
+base <https://example.com/>;
+use <http://www.w3.org/2001/XMLSchema#> as xs;
+
+/// Blog user.
+type User {
+	/// Unique email identifier.
+	email: required xs:string,
+
+	/// Name of the user.
+	name: xs:string,
+
+	/// Birth date of the user.
+	birthDate: xs:date
+}
+
+/// Blog post.
+type BlogPost {
+	/// Title.
+	title: required xs:string,
+
+	/// Post content.
+	content: required xs:string
+}


### PR DESCRIPTION
A demo PR to show how the Spruce TreeLDR library could be used to simplify the credential definition process.

Documentation on how to use the demo is here:
https://github.com/energywebfoundation/elia-energyblocks-vcs/tree/feat/SWTCH-2484/tldr-example#treeldr